### PR TITLE
gcalc: move definition of customs inside the unit

### DIFF
--- a/gcalc/gcalc.rkt
+++ b/gcalc/gcalc.rkt
@@ -8,6 +8,11 @@
 (require racket/gui "../show-scribbling.rkt" racket/unit)
 (provide game@)
 
+(define game@ (unit (import) (export)
+
+;;;============================================================================
+;;; Customizations etc
+
 (define customs '())
 (define (add-custom! name get set type desc)
   (set! customs (append customs (list (make-custom name get set type desc)))))
@@ -18,10 +23,6 @@
      (begin (define var default)
             (add-custom! 'var (λ() var) (λ(v) (set! var v))
                          type description))]))
-(define game@ (unit (import) (export)
-
-;;;============================================================================
-;;; Customizations etc
 
 (defcustom EVAL-NOW    #t 'bool      "Evaluate immediately on application")
 (defcustom EVAL-DEPTH  18 '(int 100) "Evaluation depth limit")


### PR DESCRIPTION
If it is defined outside, it is shared between all the unit invocations and the
values are added to the list each time, so the list grows and has multiple copies.

To see the bug follow these steps:

1) Open "PLT Games.exe"
2) Click "gcalc"
3) Press F10 to open menu
4) Click "Open Examples"
5) Close "gcalc" (but don't close "PLT Games.exe")
6) Click "gcalc" again
7) Press F10 again
8) Click "Open Examples" again

The error is something like: "gcalc-examples.rktd" is not a GCalc file.

The problem is that the list custom is shared between the first(closed) and second instance of gcalc, and the custom items were added twice, so it has 12 elements instead of 6. And this produce an error reading the file. 
