### PR TITLE
mines: fix highlight of flags after win

### DIFF
--- a/mines/mines.rkt
+++ b/mines/mines.rkt
@@ -352,7 +352,9 @@
                 (if (zero? nc)
                   (autoclick-surrounding x y)
                   (set-near-hilite t x y))))
-            (when (and ready? (= cover-count THE-BOMB-COUNT)) (win)))))]
+            (when (and ready? (= cover-count THE-BOMB-COUNT))
+              (clear-area-hilite)
+              (win)))))]
      [paint-one        ; draw one tile
       (lambda (t x y)
         (let ([xloc (* x TILE-HW)]


### PR DESCRIPTION
To see the problem:

1) Almost win the game.

2) The last move must be to click on an empty square that is next to a flagged mine.

3) Then the neighbor will be highlighted in after the game is wined.

4) Press reset.

5) When the mouse is moved over any square, the old region will be unhighlighted, and a fake flag will apear.

6) (If you move the mouse over the fake flag, it will disapear.)