### PR TITLE
cards: fix behavior of make-card with custom-sized images

### DIFF
--- a/cards/cards.scrbl
+++ b/cards/cards.scrbl
@@ -37,8 +37,9 @@ can only be on one table at a time.}
 Returns a single card given a bitmap for the front, an optional bitmap
 for the back, and arbitrary values for the card's suit and value
 (which are returned by the card's @method[card<%> get-value] and
-@method[card<%> get-suit-id] methods). All provided bitmaps should be
-the same size.}
+@method[card<%> get-suit-id] methods). If @racket[back-bm] is @racket[#f],
+then the back defaults to a standard 71 by 96 bitmap. The front and back
+must be the same size.}
 
 @defproc[(shuffle-list [lst list?] [n exact-nonnegative-integer?])
          list?]{

--- a/cards/make-cards.rkt
+++ b/cards/make-cards.rkt
@@ -7,7 +7,7 @@
            (contract-out
             [make-card (->i ([front-bm (back-bm)
                                        (and/c (is-a?/c mred:bitmap%)
-                                              (same-size back-bm))]
+                                              (same-size (or back-bm back)))]
                              [back-bm (or/c #f (is-a?/c mred:bitmap%))]
                              [suit-id any/c]
                              [value any/c])
@@ -88,8 +88,8 @@
 			  (vloop (sub1 value))))))))))
   
   (define (make-card front-bm back-bm suit-id value)
-    (let ([w (send back get-width)]
-	  [h (send back get-height)])
+    (let ([w (send front-bm get-width)]
+	  [h (send front-bm get-height)])
       (make-object card-class:card%
 		   suit-id
 		   value
@@ -98,6 +98,6 @@
 		   (lambda () (make-dim front-bm))
 		   (lambda ()
 		     (if back-bm 
-			 (make-dim back)
+			 (make-dim back-bm)
 			 dim-back))
                    (make-hash)))))


### PR DESCRIPTION
Fix for #5 

Also updates contract and docs to clarify behavior when back-bm is #f.  I tried to be minimal regarding the default back.  Please let me know if there's anything I should be doing differently or what I should do with my test cases.