### PR TITLE
gobblet: Results that are not lists are not useful

### DIFF
--- a/gobblet/explore.rkt
+++ b/gobblet/explore.rkt
@@ -91,8 +91,9 @@
                                             steps (min max-depth one-step-depth)
                                             (play->string v))
                                 v))
-                        ;; We have at least one result, now.
-                        (semaphore-post once-sema)
+                        (when (list? (cdr result))
+                          ;; We have at least one result, now.
+                          (semaphore-post once-sema))
                         ;; If we could learn more by searching deeper, then
                         ;;  do so.
                         (unless (or (and (= steps max-steps)


### PR DESCRIPTION
Hopefully this will fix the long-standing intermittent failure
in this code. Unfortunately, these bugs are hard to reproduce
because the multi-threaded nature of the code means they're non-
deterministic, but this change successfully passed 100x more
iterations than usual.

Related to #12.